### PR TITLE
Fixed parsing not working after new endpoint rename

### DIFF
--- a/src/tx-parsing/parsing.ts
+++ b/src/tx-parsing/parsing.ts
@@ -14,12 +14,12 @@ export async function ParseTx(
   client: MemechanClient,
 ): Promise<
   | (
-      | NewBPInstructionParsed
-      | SwapYInstructionParsed
-      | SwapXInstructionParsed
-      | InitStakingPoolInstructionParsed
-      | GoLiveInstructionParsed
-    )[]
+    | NewBPInstructionParsed
+    | SwapYInstructionParsed
+    | SwapXInstructionParsed
+    | InitStakingPoolInstructionParsed
+    | GoLiveInstructionParsed
+  )[]
   | undefined
 > {
   const pt = await client.connection.getParsedTransaction(txSig);
@@ -69,8 +69,8 @@ async function ptx(
   | undefined
 > {
   const ixBytesSliced = ixBytes.subarray(0, 2);
-  if (ixBytesSliced.equals(Buffer.from([0x87, 0x2c]))) {
-    console.log("parsing ix: New");
+  if (ixBytesSliced.equals(Buffer.from([0x26, 0x3f]))) {
+    console.log("parsing ix: NewPool");
     return await ParseNewBPInstruction(tx, index, memechanProgram);
   }
   if (ixBytesSliced.equals(Buffer.from([0x41, 0x3f]))) {

--- a/test/TxParsing.test.ts
+++ b/test/TxParsing.test.ts
@@ -4,11 +4,12 @@ import { client } from "./common/common";
 describe("Tx Parsing", () => {
   it("all", async () => {
     const txSigs = [
-      "2VdDDYqwqt91r7PzeBdt4ZKLoR6sqyZnY29EoMZC9vXVahocHYS9rmuTSNc9opUjZPQQdpZu9mV4yiLUgqRWbMW2", // new
-      "Tp3CNg1Y7ep3rTyCqfAVA2jNDbQ5eyzt9bhBEbSkZJdvjCmDmhSJ4PpCB4fDShGzWYS4kHLdpZaykk8acX1hdSC", // swapY
-      "31LuwD66Uy6msxy1XGSX2epxvp3qc9CCWHwudQFkABuJZ5RXSfv1h2RwqbMM4YovvugbzkGHxxVchtVxAKFfQhpC", // swapX
-      "5H2yQkoK1kKkRLZ7VD38oBVsuA52hzKdUghBPjZu4jUvuDsykzZTeNeaFfkL3X6FfEuYbYx62E89NWGAabAq38md", // InitStakingPool
-      "2VZQsKybUVF1QDpVpa19nW2XXw5faZApVknAvr1kRHeVAQVVY73KzVcoHFsXQQ3zzDsdTKK5ui8euDdERJr3vwAb", // GoLive
+      "k4eiJmPATkjGbVXZn5EmjnpVHL8R8NXNu9LxXvrPruPHV2KR5oePTUUHBCJbpXHM3neZQHErApzN9cbN35yUEux", // newPool (null)
+      "66oryLCS9H5Fr1MZ7ELw848jcaVXfVcAx37QRTj3BBxmQjG8nEc86MFhU5MJF9MV9qJPveSXE58p1yTP9RE4ntLo", // newPool
+      "4Jw255zfpNg3D1kNcVWJTbNKyt8gE6fdEcezR3HqpdS1QaeBaqjhw1WXDxhMjnc2y87abaEsdKWaHM7WCKvSaJyZ", // swapY
+      "5qVty11hMwcG6da19scFzj1JFG4YeM5trAtRdsbi7csUnrZqTroPrgRG25jY4ujDWx3XRupYjTVm8Zdyc6Z6eZCx", // swapX
+      "2PtG1vnaGrKWsARCYpbcGvVHfftfNc2YPqhLn11yZYwJUN5d7xRBhQ768T6HSSVUvpz2wqsCyBcTzBnx9i2Yv7AM", // InitStakingPool
+      "23LnCq3wcTpP6dhVDkGkdc2D2RyVCm2Kr56D3Jf56AiFSBdqCxe8TN1jKmkVwVBKq6NiNaVuYEuE9otjwcQwdJRJ", // GoLive
     ];
 
     for (let i = 0; i < txSigs.length; i++) {


### PR DESCRIPTION
Anchor calcs hash from endpoint name and uses it as first couple of bytes in calls, so we'll need to update sdk after each such change anyway.